### PR TITLE
keep migrations going for 5.x

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,7 @@
+bot:
+  abi_migration_branches:
+    # 5.x is what openmpi 5 uses
+    - 5.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
openmpi 5 uses 5.x
